### PR TITLE
fix(implementation)!: make it read stdin char by char

### DIFF
--- a/nyan.py
+++ b/nyan.py
@@ -2,6 +2,7 @@ import sys
 import os
 import pathlib
 import re
+import sys
 from helper import Param, ParamItem
 from helper import Helper
 
@@ -41,7 +42,6 @@ LANG = {
 def return_(v, e=1):
     print(v)
     exit(e)
-
 
 def run(filename):
     if not os.path.exists(filename):
@@ -92,7 +92,7 @@ def run(filename):
             case ".":
                 print(chr(memory.get(pointer, 0)), end="")
             case ",":
-                memory[pointer] = ord((lambda ip: ip[0])(i if (i := input()) else "\x00"))
+                memory[pointer] = ord(i) if (i := sys.stdin.read(1)) else 0
             case "~":
                 if memory.get(pointer, 0) == 0:
                     cursor = next_points[cursor]


### PR DESCRIPTION
본 PR은 기존의 `nyan.py` 구현체가 `,` 명령어를 문자 단위로 받을 수 있도록 수정한 내용입니다. 이외의 부분은 수정되지 않았습니다.

## 테스트

(유닛 테스트 코드가 없는 것 같아서) 다음 코드로 직접 테스트해보실 수 있습니다.

```bf
,?,?,!!뀨?뀨?뀨
```

1. 위 파일을 `echo.nyan` 으로 저장합니다.
2. 기존 버전에서의 동작을 확인합니다.

```bash
$ echo -n A\nB\nC | python3 ./nyan.py run ./echo.nyan
65
66
67
```

A, B, C 를 개행으로 구분해야 인식한다는 것을 알 수 있습니다.

3. 기존 버전에서의 에러를 확인합니다.

```bash
echo -n ABC | python3 ./nyan.py run ./echo.nyan
Traceback (most recent call last):
  File "/home/abiria/clone/abiria-nyanlang/./nyan.bak.py", line 146, in <module>
    run(' '.join(f))
  File "/home/abiria/clone/abiria-nyanlang/./nyan.bak.py", line 95, in run
    memory[pointer] = ord((lambda ip: ip[0])(i if (i := input()) else "\x00"))
EOFError: EOF when reading a line
```

4. 수정된 버전에서의 결과를 확인합니다.

```bash
echo -n ABC | python3 ./nyan.py run ./echo.nyan
65
66
67
```